### PR TITLE
Prevent flush() while iterating (hard safety)

### DIFF
--- a/src/ecs/World.ts
+++ b/src/ecs/World.ts
@@ -52,6 +52,7 @@ export class World implements WorldI
 
     public flush(): void
     {
+        this._ensureNotIterating("flush");
         const ops = this.commands.drain();
         for (const op of ops) this._apply(op);
     }


### PR DESCRIPTION
Since flush() applies structural changes, calling it while iterating should throw the same way as add/remove/despawn.